### PR TITLE
[SAL] Use more specific probes

### DIFF
--- a/charts/nebulous-sal/templates/deployment.yaml
+++ b/charts/nebulous-sal/templates/deployment.yaml
@@ -132,14 +132,20 @@ spec:
             - name: script-volume
               mountPath: /usr/local/tomcat/scripts/
           livenessProbe:
-            tcpSocket:
-              port: 8080
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl -X POST localhost:8080/sal/pagateway/connect
             failureThreshold: 5
             initialDelaySeconds: 60
             periodSeconds: 30
           readinessProbe:
-            tcpSocket:
-              port: 8080
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl -X POST localhost:8080/sal/pagateway/connect
             failureThreshold: 5
             initialDelaySeconds: 60
             periodSeconds: 10


### PR DESCRIPTION
After discussing with ActiveEon, I found that the best probe
to use is curling the POST at /sal/pagateway/connect as it
ensures that SAL is healthy and ready to handle other requests.
