### PR TITLE
nebulous-gui-controller: switch the startup image to busybox

### DIFF
--- a/charts/nebulous-gui-controller/Chart.yaml
+++ b/charts/nebulous-gui-controller/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nebulous-gui-controller/templates/deployment.yaml
+++ b/charts/nebulous-gui-controller/templates/deployment.yaml
@@ -29,8 +29,13 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-for-mongodb
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.waitForMongodb.image.repository }}:{{ .Values.waitForMongodb.image.tag }}"
+          imagePullPolicy: {{ .Values.waitForMongodb.image.pullPolicy }}
           command: ['sh', '-c', 'until nc -z nebulous-gui-controller-mongodb 27017; do echo waiting for mongodb; sleep 2; done;']
+          resources:
+            {{- toYaml .Values.waitForMongodb.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.waitForMongodb.securityContext | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/nebulous-gui-controller/values.yaml
+++ b/charts/nebulous-gui-controller/values.yaml
@@ -85,6 +85,14 @@ mongodb:
   # this enables the built-in mongodb deployment - not recommended for production
   enabled: true
 
+waitForMongodb:
+  image:
+    repository: "busybox"
+    pullPolicy: IfNotPresent
+    tag: "1-musl"
+  resources: {}
+  securityContext: {}
+
 env:
   - name: ACTIVEMQ_HOST
     value: "nebulous-activemq"


### PR DESCRIPTION
Then there is no need to carry `nc` in the actual container image.
