### PR TITLE
ems-server: Added custom liveness and readiness periods, and initial delays

### DIFF
--- a/charts/ems-server/Chart.yaml
+++ b/charts/ems-server/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 7.0.0-SNAPSHOT
 description: EMS server Helm chart for Kubernetes
 name: ems-server
 type: application
-version: 0.1.1
+version: 0.1.2

--- a/charts/ems-server/templates/deployment.yaml
+++ b/charts/ems-server/templates/deployment.yaml
@@ -105,9 +105,13 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
+            periodSeconds: {{ .Values.livenessProbePeriod }}
+            initialDelaySeconds: {{ .Values.livenessProbeInitDelay }}
           readinessProbe:
             tcpSocket:
               port: http
+            periodSeconds: {{ .Values.readinessProbePeriod }}
+            initialDelaySeconds: {{ .Values.readinessProbeInitDelay }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/ems-server/values.yaml
+++ b/charts/ems-server/values.yaml
@@ -91,6 +91,11 @@ tolerations: []
 
 affinity: {}
 
+livenessProbeInitDelay: 300
+livenessProbePeriod: 30
+readinessProbeInitDelay: 300
+readinessProbePeriod: 30
+
 ports:
   - name: http
     containerPort: 8111


### PR DESCRIPTION
…for ems server pod. Default values: 300s init delays, 30s periods